### PR TITLE
fix: make artifact-coverage-directory input not required in sonar_cloud_scan_python workflow

### DIFF
--- a/.github/workflows/sonar_cloud_scan_python.yml
+++ b/.github/workflows/sonar_cloud_scan_python.yml
@@ -10,7 +10,7 @@ on:
         default: 'coverage'
       artifact-coverage-directory:
         description: 'Artifact coverage directory with results of tests'
-        required: true
+        required: false
         type: string
         default: '.'
       artifact-coverage-path:


### PR DESCRIPTION
## Problem

`artifact-coverage-directory` input in `sonar_cloud_scan_python.yml` was declared as `required: true` while also having `default: '.'`. GitHub Actions validates required inputs at parse time, forcing every caller to explicitly provide the input even though a default exists.

This caused the following error in downstream repos:
```
The workflow is not valid. .github/workflows/ci.yaml (Line: 40, Col: 11):
Input artifact-coverage-directory is required, but not provided while calling.
```

## Fix

Changed `required: true` → `required: false` for `artifact-coverage-directory` since the default value `'.'\ already covers the optional case.