### PR TITLE
fix: load image locally and fix trivy image-ref and condition in validate_dockerfile workflow

### DIFF
--- a/.github/workflows/validate_dockerfile.yml
+++ b/.github/workflows/validate_dockerfile.yml
@@ -88,18 +88,18 @@ jobs:
         id: build-push
         if: steps.filter.outputs.dockerfile == 'true'
         with:
-          push: ${{ inputs.docker-push  }}
-          file: ${{ inputs.dockerfile  }}
-          context: ${{ inputs.dockerfile-context  }}
+          push: ${{ inputs.docker-push }}
+          load: ${{ !inputs.docker-push }}
+          file: ${{ inputs.dockerfile }}
+          context: ${{ inputs.dockerfile-context }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@v0.36.0
-        if: steps.filter.outputs.dockerfile == 'true' && "${{ inputs.trivy-scan }} == true"
+        if: steps.filter.outputs.dockerfile == 'true' && inputs.trivy-scan == true
         with:
-          image-ref: 'ghcr.io/${{ github.repository }}:${{ steps.build-push.outputs.imageid }}'
-          scan-ref: 'ghcr.io/${{ github.repository }}:${{ steps.build-push.outputs.imageid }}'
+          image-ref: ${{ steps.build-push.outputs.imageid }}
           format: ${{ inputs.trivy-scan-output }}
           exit-code: '1'
-          skip-dirs: ${{ inputs.trivy-skip-dirs	}}
+          skip-dirs: ${{ inputs.trivy-skip-dirs }}


### PR DESCRIPTION
## Problems

Three bugs in `validate_dockerfile.yml`:

### 1. `build-push` step missing `load: true`
When `docker-push: false` (default), the image is built in the BuildKit cache but never loaded into the local Docker daemon. As a result `steps.build-push.outputs.imageid` is empty (or unavailable to subsequent steps).

### 2. Trivy `image-ref` pointed to an unpushed registry image
```yaml
image-ref: 'ghcr.io/${{ github.repository }}:${{ steps.build-push.outputs.imageid }}'
```
With `imageid` empty this resolves to `ghcr.io/org/repo:` — an invalid reference — causing:
```
Fatal error: failed to parse the image name: could not parse reference: ghcr.io/xoanmm/python-app-devsecops:
```

### 3. Broken trivy `if` condition
```yaml
if: steps.filter.outputs.dockerfile == 'true' && "${{ inputs.trivy-scan }} == true"
```
The second operand is a **string** (`"true == true"`), not a boolean expression — it is always truthy, making the condition equivalent to only checking the dockerfile filter.

## Fixes

- Added `load: ${{ !inputs.docker-push }}` to the build step so the image is loaded into the local Docker daemon when not pushing.
- Changed `image-ref` to `${{ steps.build-push.outputs.imageid }}` (the local sha256 image ID populated by `load: true`).
- Removed the broken `scan-ref` duplicate field.
- Fixed the trivy `if` condition to `inputs.trivy-scan == true` (proper boolean expression).